### PR TITLE
Add support for the story search API method

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This gem is a lightweight API wrapper. That means you'll need to refer to the
 [API documentation](https://clubhouse.io/api/rest/v2/) to figure out what resources
  and actions exist.
 
-On the plus side, once you know what you want to do, using this gem should be 
+On the plus side, once you know what you want to do, using this gem should be
 simple.
 
 Instantiate an object to interface with the API:
@@ -61,7 +61,7 @@ clubhouse = ClubhouseRuby::Clubhouse.new(<YOUR CLUBHOUSE API TOKEN>, response_fo
 
 Then, call methods on the object matching the resource(s) and action you are
 interested in. For example, if you want to list all available epics, you need to
-access the endpoint at https://api.clubhouse.io/api/v1/epics. The 
+access the endpoint at https://api.clubhouse.io/api/v1/epics. The
 clubhouse_ruby gem uses an explicit action:
 
 ```ruby
@@ -144,6 +144,28 @@ clubhouse.projects(<project_id>).stories.list
 #       ...
 #     }, ...
 #   ]
+# }
+```
+
+You can search stories, using standard Clubhouse [search operators](https://help.clubhouse.io/hc/en-us/articles/360000046646-Search-Operators):
+
+```ruby
+clubhouse.search_stories(page_size: 25, query: 'state:500000016')
+# => {
+#   code: "200",
+#   status: "OK",
+#   content: {
+#     "next" => "/api/v2/search/stories?query=state%3A500000016&page_size=25&next=a8acc6577548df7a213272f7f9f617bcb1f8a831~24",
+#     "data" => [
+#       {
+#         "entity_type" => "story",
+#         "archived" => false,
+#         "created_at" => "...",
+#         "updated_at" => "...",
+#         ...
+#       }, ...
+#     ]
+#   }
 # }
 ```
 

--- a/lib/clubhouse_ruby/constants.rb
+++ b/lib/clubhouse_ruby/constants.rb
@@ -53,6 +53,10 @@ module ClubhouseRuby
     bulk_update: {
       path: :bulk,
       action: :Put
+    },
+    search_stories: {
+      path: 'search/stories',
+      action: :Get
     }
   }.freeze
 end

--- a/spec/clubhouse_ruby/request_spec.rb
+++ b/spec/clubhouse_ruby/request_spec.rb
@@ -143,6 +143,20 @@ describe ClubhouseRuby::Request do
         expect(clubhouse[:content].first['id']).to eq(29)
         expect(clubhouse[:content].first['archived']).to eq(true)
       end
+
+      it 'searches stories', :vcr do
+        params = {
+          query: '!is:archived ',
+          page_size: 5
+        }
+        clubhouse = new_clubhouse.search_stories(params)
+
+        expect(clubhouse[:code]).to eq('200')
+        expect(clubhouse[:status]).to eq('OK')
+        expect(clubhouse[:content]['data'].count).to eq(5)
+        expect(clubhouse[:content]['data'].first['id']).to eq(32)
+        expect(clubhouse[:content]['data'].first['archived']).to eq(false)
+      end
     end
   end
 end

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/searches_stories.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/searches_stories.yml
@@ -1,0 +1,56 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.clubhouse.io/api/v2/search/stories
+    body:
+      encoding: UTF-8
+      string: '{"query":"!is:archived ","page_size":5}'
+    headers:
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      User-Agent:
+      - Ruby
+      Host:
+      - api.clubhouse.io
+      Content-Type:
+      - application/json
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 25 Oct 2018 02:41:19 GMT
+      Content-Type:
+      - application/json;charset=utf-8
+      Content-Length:
+      - '622'
+      Connection:
+      - keep-alive
+      Vary:
+      - Accept-Encoding
+      Database-Time:
+      - '153773423'
+      Clubhouse-Company:
+      - ''
+      Clubhouse-Organization:
+      - ''
+      Access-Control-Expose-Headers:
+      - Database-Time, CH-Paginate-Incomplete, CH-Start-Time, CH-End-Time, Clubhouse-Company,
+        Clubhouse-Organization
+      Server:
+      - Jetty(9.4.z-SNAPSHOT)
+    body:
+      encoding: ASCII-8BIT
+      string: '{"next":"\/api\/v2\/search\/stories?query=%21is%3Aarchived+&page_size=5&next=9acaf56dbfb45eda009dd3f30788c06323ec16cc~4","data":[{"entity_type":"story","archived":false,"created_at":"2018-10-25T02:40:20Z","updated_at":"2018-10-25T02:40:20Z","id":32,"external_id":null,"name":"Test
+        Story 26","story_type":"feature","position":12149122048,"workflow_state_id":500000008,"moved_at":"2018-10-25T02:40:20Z","started":false,"started_at":null,"started_at_override":null,"completed":false,"completed_at":null,"completed_at_override":null,"blocker":false,"blocked":false,"estimate":null,"deadline":null,"project_id":6,"labels":[],"requested_by_id":"5bd12c8c-28ed-496e-8f9b-ac655c315265","owner_ids":[],"follower_ids":["5bd12c8c-28ed-496e-8f9b-ac655c315265"],"mention_ids":[],"epic_id":null,"story_links":[],"app_url":"https:\/\/app.clubhouse.io\/recurser\/story\/32","description":""},{"entity_type":"story","archived":false,"created_at":"2018-10-25T02:40:17Z","updated_at":"2018-10-25T02:40:17Z","id":31,"external_id":null,"name":"Test
+        Story 25","story_type":"feature","position":12149056512,"workflow_state_id":500000008,"moved_at":"2018-10-25T02:40:17Z","started":false,"started_at":null,"started_at_override":null,"completed":false,"completed_at":null,"completed_at_override":null,"blocker":false,"blocked":false,"estimate":null,"deadline":null,"project_id":6,"labels":[],"requested_by_id":"5bd12c8c-28ed-496e-8f9b-ac655c315265","owner_ids":[],"follower_ids":["5bd12c8c-28ed-496e-8f9b-ac655c315265"],"mention_ids":[],"epic_id":null,"story_links":[],"app_url":"https:\/\/app.clubhouse.io\/recurser\/story\/31","description":""},{"entity_type":"story","archived":false,"created_at":"2018-10-25T02:40:14Z","updated_at":"2018-10-25T02:40:14Z","id":30,"external_id":null,"name":"Test
+        Story 24","story_type":"feature","position":12148990976,"workflow_state_id":500000008,"moved_at":"2018-10-25T02:40:14Z","started":false,"started_at":null,"started_at_override":null,"completed":false,"completed_at":null,"completed_at_override":null,"blocker":false,"blocked":false,"estimate":null,"deadline":null,"project_id":6,"labels":[],"requested_by_id":"5bd12c8c-28ed-496e-8f9b-ac655c315265","owner_ids":[],"follower_ids":["5bd12c8c-28ed-496e-8f9b-ac655c315265"],"mention_ids":[],"epic_id":null,"story_links":[],"app_url":"https:\/\/app.clubhouse.io\/recurser\/story\/30","description":""},{"entity_type":"story","archived":false,"created_at":"2018-10-25T02:40:11Z","updated_at":"2018-10-25T02:40:11Z","id":29,"external_id":null,"name":"Test
+        Story 23","story_type":"feature","position":12148925440,"workflow_state_id":500000008,"moved_at":"2018-10-25T02:40:11Z","started":false,"started_at":null,"started_at_override":null,"completed":false,"completed_at":null,"completed_at_override":null,"blocker":false,"blocked":false,"estimate":null,"deadline":null,"project_id":6,"labels":[],"requested_by_id":"5bd12c8c-28ed-496e-8f9b-ac655c315265","owner_ids":[],"follower_ids":["5bd12c8c-28ed-496e-8f9b-ac655c315265"],"mention_ids":[],"epic_id":null,"story_links":[],"app_url":"https:\/\/app.clubhouse.io\/recurser\/story\/29","description":""},{"entity_type":"story","archived":false,"created_at":"2018-10-25T02:40:08Z","updated_at":"2018-10-25T02:40:08Z","id":28,"external_id":null,"name":"Test
+        Story 22","story_type":"feature","position":12148859904,"workflow_state_id":500000008,"moved_at":"2018-10-25T02:40:08Z","started":false,"started_at":null,"started_at_override":null,"completed":false,"completed_at":null,"completed_at_override":null,"blocker":false,"blocked":false,"estimate":null,"deadline":null,"project_id":6,"labels":[],"requested_by_id":"5bd12c8c-28ed-496e-8f9b-ac655c315265","owner_ids":[],"follower_ids":["5bd12c8c-28ed-496e-8f9b-ac655c315265"],"mention_ids":[],"epic_id":null,"story_links":[],"app_url":"https:\/\/app.clubhouse.io\/recurser\/story\/28","description":""}],"total":26}'
+    http_version: 
+  recorded_at: Thu, 25 Oct 2018 02:41:19 GMT
+recorded_with: VCR 3.0.3


### PR DESCRIPTION
Implements the [Search API](https://clubhouse.io/api/rest/v2/#Search).

I noticed that https://github.com/PhilipCastiglione/clubhouse_ruby/commit/5551d12f8c7c3f92e430e01ea49537ee66aad124 is similar - is that an old API method? 