### PR TITLE
Switch API URL to new Shortcut URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,11 @@ less code and maintenance effort, allowing the developer to be lazy. A
 reasonable person might fairly assume this to be the true rationale behind the
 philosophy. They'd be right.
 
+## Name Change to *Shortcut*
+
+*Clubhouse* has changed its name to *Shortcut* and has changed API URLs. This 
+gem is using the new URL, but has not otherwise updated the name.
+
 ## Installation
 
 Add this line to your application's Gemfile:
@@ -61,7 +66,7 @@ clubhouse = ClubhouseRuby::Clubhouse.new(<YOUR CLUBHOUSE API TOKEN>, response_fo
 
 Then, call methods on the object matching the resource(s) and action you are
 interested in. For example, if you want to list all available epics, you need to
-access the endpoint at https://api.clubhouse.io/api/v1/epics. The
+access the endpoint at https://api.app.shortcut.com/api/v1/epics. The
 clubhouse_ruby gem uses an explicit action:
 
 ```ruby

--- a/clubhouse_ruby.gemspec
+++ b/clubhouse_ruby.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = 'https://github.com/PhilipCastiglione/clubhouse_ruby'
   spec.license       = 'MIT'
 
-  spec.files         = `git ls-files -z`.split('\x0').reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']

--- a/lib/clubhouse_ruby/constants.rb
+++ b/lib/clubhouse_ruby/constants.rb
@@ -2,7 +2,7 @@ require 'json'
 require 'csv'
 
 module ClubhouseRuby
-  API_URL = "https://api.clubhouse.io/api/v3/".freeze
+  API_URL = "https://api.app.shortcut.com/api/v3/".freeze
 
   # Response formats the clubhouse api knows about
   FORMATS = {

--- a/lib/clubhouse_ruby/path_builder.rb
+++ b/lib/clubhouse_ruby/path_builder.rb
@@ -16,7 +16,7 @@ module ClubhouseRuby
     #
     # This example will execute a call to:
     #
-    # `https://api.clubhouse.io/api/v3/stories/{story-id}/comments/{comment-id}`
+    # `https://api.app.shortcut.com/api/v3/stories/{story-id}/comments/{comment-id}`
     #
     # with arguments:
     #

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/creates_an_epic.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/creates_an_epic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.clubhouse.io/api/v3/epics
+    uri: https://api.app.shortcut.com/api/v3/epics
     body:
       encoding: UTF-8
       string: '{"name":"A new test epic","state":"to do"}'
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/creates_multiple_stories.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/creates_multiple_stories.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.clubhouse.io/api/v3/stories/bulk
+    uri: https://api.app.shortcut.com/api/v3/stories/bulk
     body:
       encoding: UTF-8
       string: '{"stories":[{"project_id":5,"name":"Some new"},{"project_id":5,"name":"Test
@@ -15,7 +15,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/deletes_an_epic.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/deletes_an_epic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: delete
-    uri: https://api.clubhouse.io/api/v3/epics/25
+    uri: https://api.app.shortcut.com/api/v3/epics/25
     body:
       encoding: UTF-8
       string: "{}"
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/gets_a_project.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/gets_a_project.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.clubhouse.io/api/v3/projects/5
+    uri: https://api.app.shortcut.com/api/v3/projects/5
     body:
       encoding: UTF-8
       string: "{}"
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/gets_an_epic.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/gets_an_epic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.clubhouse.io/api/v3/epics/25
+    uri: https://api.app.shortcut.com/api/v3/epics/25
     body:
       encoding: UTF-8
       string: "{}"
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/lists_all_epics.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/lists_all_epics.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.clubhouse.io/api/v3/epics
+    uri: https://api.app.shortcut.com/api/v3/epics
     body:
       encoding: UTF-8
       string: "{}"
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/lists_all_stories_for_a_project.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/lists_all_stories_for_a_project.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.clubhouse.io/api/v3/projects/5/stories
+    uri: https://api.app.shortcut.com/api/v3/projects/5/stories
     body:
       encoding: UTF-8
       string: "{}"
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/reports_errors_for_a_missing_epic.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/reports_errors_for_a_missing_epic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.clubhouse.io/api/v3/epics/25
+    uri: https://api.app.shortcut.com/api/v3/epics/25
     body:
       encoding: UTF-8
       string: "{}"
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/reports_errors_for_bad_params.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/reports_errors_for_bad_params.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: post
-    uri: https://api.clubhouse.io/api/v3/epics
+    uri: https://api.app.shortcut.com/api/v3/epics
     body:
       encoding: UTF-8
       string: '{"foo":"bar"}'
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/searches_stories.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/searches_stories.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://api.clubhouse.io/api/v3/search/stories
+    uri: https://api.app.shortcut.com/api/v3/search/stories
     body:
       encoding: UTF-8
       string: '{"query":"!is:archived ","page_size":5}'
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/updates_an_epic.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/updates_an_epic.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://api.clubhouse.io/api/v3/epics/25
+    uri: https://api.app.shortcut.com/api/v3/epics/25
     body:
       encoding: UTF-8
       string: '{"state":"in progress"}'
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:

--- a/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/updates_multiple_stories.yml
+++ b/spec/vcr_cassettes/ClubhouseRuby_Request/_fetch/with_er_some_non-exhaustive_examples_of_api_calls/updates_multiple_stories.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: put
-    uri: https://api.clubhouse.io/api/v3/stories/bulk
+    uri: https://api.app.shortcut.com/api/v3/stories/bulk
     body:
       encoding: UTF-8
       string: '{"story_ids":[8,15],"archived":true}'
@@ -14,7 +14,7 @@ http_interactions:
       User-Agent:
       - Ruby
       Host:
-      - api.clubhouse.io
+      - api.app.shortcut.com
       Content-Type:
       - application/json
   response:


### PR DESCRIPTION
Shortcut has announced that the old api.clubhouse.io API endpoint will stop working on 11/13/2021. This PR simply changes that URL to the new api.app.shortcut.com endpoint and updates the tests accordingly. I suppose the whole gem should be updated to the new brand, but for now I just needed to make sure my deployment scripts kept running after the 13th.